### PR TITLE
add aerobulk-python profiling

### DIFF
--- a/notebooks/paigem/profile_aerobulk-python.ipynb
+++ b/notebooks/paigem/profile_aerobulk-python.ipynb
@@ -1,0 +1,1520 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ee9c51ba",
+   "metadata": {},
+   "source": [
+    "# Profile aerobulk-python"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "7659e681",
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "                  __    __    __    __\n",
+      "                 /  \\  /  \\  /  \\  /  \\\n",
+      "                /    \\/    \\/    \\/    \\\n",
+      "███████████████/  /██/  /██/  /██/  /████████████████████████\n",
+      "              /  / \\   / \\   / \\   / \\  \\____\n",
+      "             /  /   \\_/   \\_/   \\_/   \\    o \\__,\n",
+      "            / _/                       \\_____/  `\n",
+      "            |/\n",
+      "        ███╗   ███╗ █████╗ ███╗   ███╗██████╗  █████╗\n",
+      "        ████╗ ████║██╔══██╗████╗ ████║██╔══██╗██╔══██╗\n",
+      "        ██╔████╔██║███████║██╔████╔██║██████╔╝███████║\n",
+      "        ██║╚██╔╝██║██╔══██║██║╚██╔╝██║██╔══██╗██╔══██║\n",
+      "        ██║ ╚═╝ ██║██║  ██║██║ ╚═╝ ██║██████╔╝██║  ██║\n",
+      "        ╚═╝     ╚═╝╚═╝  ╚═╝╚═╝     ╚═╝╚═════╝ ╚═╝  ╚═╝\n",
+      "\n",
+      "        mamba (0.4.2) supported by @QuantStack\n",
+      "\n",
+      "        GitHub:  https://github.com/QuantStack/mamba\n",
+      "        Twitter: https://twitter.com/QuantStack\n",
+      "\n",
+      "█████████████████████████████████████████████████████████████\n",
+      "\n",
+      "pkgs/r/osx-64            [>                   ] (--:--) No change\n",
+      "pkgs/r/osx-64            [====================] (00m:00s) No change\n",
+      "pkgs/r/osx-64            [====================] (00m:00s) No change\n",
+      "pkgs/r/noarch            [=>                  ] (--:--) No change\n",
+      "pkgs/r/noarch            [====================] (00m:00s) No change\n",
+      "pkgs/r/noarch            [====================] (00m:00s) No change\n",
+      "pkgs/main/noarch         [<=>                 ] (00m:00s) \n",
+      "pkgs/main/noarch         [=>                ] (00m:00s) 540 KB / ?? (1.76 MB/s)\n",
+      "pkgs/main/noarch         [=>                ] (00m:00s) 540 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/osx-64       [<=>                 ] (00m:00s) \n",
+      "pkgs/main/noarch         [=>                ] (00m:00s) 540 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/osx-64       [=>                ] (00m:00s) 382 KB / ?? (1.24 MB/s)\n",
+      "pkgs/main/noarch         [=>                ] (00m:00s) 540 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/osx-64       [=>                ] (00m:00s) 382 KB / ?? (1.24 MB/s)\n",
+      "conda-forge/noarch       [<=>                 ] (00m:00s) \n",
+      "pkgs/main/noarch         [=>                ] (00m:00s) 540 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/osx-64       [=>                ] (00m:00s) 382 KB / ?? (1.24 MB/s)\n",
+      "conda-forge/noarch       [=>                ] (00m:00s) 378 KB / ?? (1.23 MB/s)\n",
+      "pkgs/main/noarch         [=>                ] (00m:00s) 540 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/osx-64       [=>                ] (00m:00s) 382 KB / ?? (1.24 MB/s)\n",
+      "conda-forge/noarch       [=>                ] (00m:00s) 378 KB / ?? (1.23 MB/s)\n",
+      "pkgs/main/osx-64         [<=>                 ] (00m:00s) \n",
+      "pkgs/main/noarch         [=>                ] (00m:00s) 540 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/osx-64       [=>                ] (00m:00s) 382 KB / ?? (1.24 MB/s)\n",
+      "conda-forge/noarch       [=>                ] (00m:00s) 378 KB / ?? (1.23 MB/s)\n",
+      "pkgs/main/osx-64         [=>                ] (00m:00s) 320 KB / ?? (1.04 MB/s)\n",
+      "pkgs/main/noarch         [<=>                 ] (00m:00s) Finalizing...\n",
+      "conda-forge/osx-64       [=>                ] (00m:00s) 382 KB / ?? (1.24 MB/s)\n",
+      "conda-forge/noarch       [=>                ] (00m:00s) 378 KB / ?? (1.23 MB/s)\n",
+      "pkgs/main/osx-64         [=>                ] (00m:00s) 320 KB / ?? (1.04 MB/s)\n",
+      "pkgs/main/noarch         [<=>                 ] (00m:00s) Done\n",
+      "conda-forge/osx-64       [=>                ] (00m:00s) 382 KB / ?? (1.24 MB/s)\n",
+      "conda-forge/noarch       [=>                ] (00m:00s) 378 KB / ?? (1.23 MB/s)\n",
+      "pkgs/main/osx-64         [=>                ] (00m:00s) 320 KB / ?? (1.04 MB/s)\n",
+      "pkgs/main/noarch         [====================] (00m:00s) Done\n",
+      "conda-forge/osx-64       [=>                ] (00m:00s) 382 KB / ?? (1.24 MB/s)\n",
+      "conda-forge/noarch       [=>                ] (00m:00s) 378 KB / ?? (1.23 MB/s)\n",
+      "pkgs/main/osx-64         [=>                ] (00m:00s) 320 KB / ?? (1.04 MB/s)\n",
+      "pkgs/main/noarch         [====================] (00m:00s) Done\n",
+      "conda-forge/osx-64       [=>                ] (00m:00s) 382 KB / ?? (1.24 MB/s)\n",
+      "conda-forge/noarch       [=>                ] (00m:00s) 378 KB / ?? (1.23 MB/s)\n",
+      "pkgs/main/osx-64         [=>                ] (00m:00s) 320 KB / ?? (1.04 MB/s)\n",
+      "conda-forge/osx-64       [<=>               ] (00m:00s) 382 KB / ?? (1.24 MB/s)\n",
+      "conda-forge/noarch       [=>                ] (00m:00s) 378 KB / ?? (1.23 MB/s)\n",
+      "pkgs/main/osx-64         [=>                ] (00m:00s) 320 KB / ?? (1.04 MB/s)\n",
+      "conda-forge/osx-64       [<=>               ] (00m:00s) 813 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/noarch       [=>                ] (00m:00s) 378 KB / ?? (1.23 MB/s)\n",
+      "pkgs/main/osx-64         [=>                ] (00m:00s) 320 KB / ?? (1.04 MB/s)\n",
+      "conda-forge/osx-64       [<=>               ] (00m:00s) 813 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/noarch       [<=>               ] (00m:00s) 378 KB / ?? (1.23 MB/s)\n",
+      "pkgs/main/osx-64         [=>                ] (00m:00s) 320 KB / ?? (1.04 MB/s)\n",
+      "conda-forge/osx-64       [<=>               ] (00m:00s) 813 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/noarch       [<=>               ] (00m:00s) 958 KB / ?? (2.08 MB/s)\n",
+      "pkgs/main/osx-64         [=>                ] (00m:00s) 320 KB / ?? (1.04 MB/s)\n",
+      "conda-forge/osx-64       [<=>               ] (00m:00s) 813 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/noarch       [<=>               ] (00m:00s) 958 KB / ?? (2.08 MB/s)\n",
+      "pkgs/main/osx-64         [<=>               ] (00m:00s) 320 KB / ?? (1.04 MB/s)\n",
+      "conda-forge/osx-64       [<=>               ] (00m:00s) 813 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/noarch       [<=>               ] (00m:00s) 958 KB / ?? (2.08 MB/s)\n",
+      "pkgs/main/osx-64         [<=>               ] (00m:00s) 904 KB / ?? (1.96 MB/s)\n",
+      "conda-forge/osx-64       [<=>               ] (00m:00s) 813 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/noarch       [ <=>              ] (00m:00s) 958 KB / ?? (2.08 MB/s)\n",
+      "pkgs/main/osx-64         [<=>               ] (00m:00s) 904 KB / ?? (1.96 MB/s)\n",
+      "conda-forge/osx-64       [<=>               ] (00m:00s) 813 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/noarch       [  <=>               ] (00m:00s) 2 MB / ?? (2.65 MB/s)\n",
+      "pkgs/main/osx-64         [<=>               ] (00m:00s) 904 KB / ?? (1.96 MB/s)\n",
+      "conda-forge/osx-64       [<=>               ] (00m:00s) 813 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/noarch       [  <=>               ] (00m:00s) 2 MB / ?? (2.65 MB/s)\n",
+      "pkgs/main/osx-64         [ <=>              ] (00m:00s) 904 KB / ?? (1.96 MB/s)\n",
+      "conda-forge/osx-64       [<=>               ] (00m:00s) 813 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/noarch       [  <=>               ] (00m:00s) 2 MB / ?? (2.65 MB/s)\n",
+      "pkgs/main/osx-64         [  <=>               ] (00m:00s) 1 MB / ?? (2.32 MB/s)\n",
+      "conda-forge/osx-64       [ <=>              ] (00m:00s) 813 KB / ?? (1.76 MB/s)\n",
+      "conda-forge/noarch       [  <=>               ] (00m:00s) 2 MB / ?? (2.65 MB/s)\n",
+      "pkgs/main/osx-64         [  <=>               ] (00m:00s) 1 MB / ?? (2.32 MB/s)\n",
+      "conda-forge/osx-64       [  <=>               ] (00m:00s) 1 MB / ?? (2.49 MB/s)\n",
+      "conda-forge/noarch       [  <=>               ] (00m:00s) 2 MB / ?? (2.65 MB/s)\n",
+      "pkgs/main/osx-64         [  <=>               ] (00m:00s) 1 MB / ?? (2.32 MB/s)\n",
+      "conda-forge/osx-64       [  <=>               ] (00m:00s) 1 MB / ?? (2.49 MB/s)\n",
+      "conda-forge/noarch       [   <=>              ] (00m:00s) 2 MB / ?? (2.65 MB/s)\n",
+      "pkgs/main/osx-64         [  <=>               ] (00m:00s) 1 MB / ?? (2.32 MB/s)\n",
+      "conda-forge/osx-64       [  <=>               ] (00m:00s) 1 MB / ?? (2.49 MB/s)\n",
+      "conda-forge/noarch       [   <=>              ] (00m:00s) 2 MB / ?? (2.62 MB/s)\n",
+      "pkgs/main/osx-64         [  <=>               ] (00m:00s) 1 MB / ?? (2.32 MB/s)\n",
+      "conda-forge/osx-64       [  <=>               ] (00m:00s) 1 MB / ?? (2.49 MB/s)\n",
+      "conda-forge/noarch       [   <=>              ] (00m:00s) 2 MB / ?? (2.62 MB/s)\n",
+      "pkgs/main/osx-64         [   <=>              ] (00m:00s) 1 MB / ?? (2.32 MB/s)\n",
+      "conda-forge/osx-64       [  <=>               ] (00m:00s) 1 MB / ?? (2.49 MB/s)\n",
+      "conda-forge/noarch       [   <=>              ] (00m:00s) 2 MB / ?? (2.62 MB/s)\n",
+      "pkgs/main/osx-64         [   <=>              ] (00m:00s) 2 MB / ?? (2.12 MB/s)\n",
+      "conda-forge/osx-64       [   <=>              ] (00m:00s) 1 MB / ?? (2.49 MB/s)\n",
+      "conda-forge/noarch       [   <=>              ] (00m:00s) 2 MB / ?? (2.62 MB/s)\n",
+      "pkgs/main/osx-64         [   <=>              ] (00m:00s) 2 MB / ?? (2.12 MB/s)\n",
+      "conda-forge/osx-64       [   <=>              ] (00m:00s) 2 MB / ?? (2.77 MB/s)\n",
+      "conda-forge/noarch       [   <=>              ] (00m:00s) 2 MB / ?? (2.62 MB/s)\n",
+      "pkgs/main/osx-64         [   <=>              ] (00m:00s) 2 MB / ?? (2.12 MB/s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "conda-forge/osx-64       [   <=>              ] (00m:00s) 2 MB / ?? (2.77 MB/s)\n",
+      "conda-forge/noarch       [    <=>             ] (00m:00s) 2 MB / ?? (2.62 MB/s)\n",
+      "pkgs/main/osx-64         [   <=>              ] (00m:00s) 2 MB / ?? (2.12 MB/s)\n",
+      "conda-forge/osx-64       [   <=>              ] (00m:00s) 2 MB / ?? (2.77 MB/s)\n",
+      "conda-forge/noarch       [    <=>             ] (00m:00s) 2 MB / ?? (2.71 MB/s)\n",
+      "pkgs/main/osx-64         [   <=>              ] (00m:00s) 2 MB / ?? (2.12 MB/s)\n",
+      "conda-forge/osx-64       [   <=>              ] (00m:00s) 2 MB / ?? (2.77 MB/s)\n",
+      "conda-forge/noarch       [    <=>             ] (00m:00s) 2 MB / ?? (2.71 MB/s)\n",
+      "pkgs/main/osx-64         [    <=>             ] (00m:00s) 2 MB / ?? (2.12 MB/s)\n",
+      "conda-forge/osx-64       [   <=>              ] (00m:00s) 2 MB / ?? (2.77 MB/s)\n",
+      "conda-forge/noarch       [    <=>             ] (00m:00s) 2 MB / ?? (2.71 MB/s)\n",
+      "pkgs/main/osx-64         [    <=>             ] (00m:00s) 2 MB / ?? (2.51 MB/s)\n",
+      "conda-forge/osx-64       [    <=>             ] (00m:00s) 2 MB / ?? (2.77 MB/s)\n",
+      "conda-forge/noarch       [    <=>             ] (00m:00s) 2 MB / ?? (2.71 MB/s)\n",
+      "pkgs/main/osx-64         [    <=>             ] (00m:00s) 2 MB / ?? (2.51 MB/s)\n",
+      "conda-forge/osx-64       [    <=>             ] (00m:00s) 3 MB / ?? (2.85 MB/s)\n",
+      "conda-forge/noarch       [    <=>             ] (00m:00s) 2 MB / ?? (2.71 MB/s)\n",
+      "pkgs/main/osx-64         [    <=>             ] (00m:00s) 2 MB / ?? (2.51 MB/s)\n",
+      "conda-forge/osx-64       [    <=>             ] (00m:00s) 3 MB / ?? (2.85 MB/s)\n",
+      "conda-forge/noarch       [     <=>            ] (00m:00s) 2 MB / ?? (2.71 MB/s)\n",
+      "pkgs/main/osx-64         [    <=>             ] (00m:00s) 2 MB / ?? (2.51 MB/s)\n",
+      "conda-forge/osx-64       [    <=>             ] (00m:00s) 3 MB / ?? (2.85 MB/s)\n",
+      "conda-forge/noarch       [     <=>            ] (00m:00s) 3 MB / ?? (2.74 MB/s)\n",
+      "pkgs/main/osx-64         [    <=>             ] (00m:00s) 2 MB / ?? (2.51 MB/s)\n",
+      "conda-forge/osx-64       [    <=>             ] (00m:00s) 3 MB / ?? (2.85 MB/s)\n",
+      "conda-forge/noarch       [     <=>            ] (00m:00s) 3 MB / ?? (2.74 MB/s)\n",
+      "pkgs/main/osx-64         [     <=>            ] (00m:00s) 2 MB / ?? (2.51 MB/s)\n",
+      "conda-forge/osx-64       [    <=>             ] (00m:00s) 3 MB / ?? (2.85 MB/s)\n",
+      "conda-forge/noarch       [     <=>            ] (00m:00s) 3 MB / ?? (2.74 MB/s)\n",
+      "pkgs/main/osx-64         [     <=>            ] (00m:00s) 3 MB / ?? (2.76 MB/s)\n",
+      "conda-forge/osx-64       [     <=>            ] (00m:00s) 3 MB / ?? (2.85 MB/s)\n",
+      "conda-forge/noarch       [     <=>            ] (00m:00s) 3 MB / ?? (2.74 MB/s)\n",
+      "pkgs/main/osx-64         [     <=>            ] (00m:00s) 3 MB / ?? (2.76 MB/s)\n",
+      "conda-forge/osx-64       [     <=>            ] (00m:00s) 3 MB / ?? (2.72 MB/s)\n",
+      "conda-forge/noarch       [     <=>            ] (00m:00s) 3 MB / ?? (2.74 MB/s)\n",
+      "pkgs/main/osx-64         [     <=>            ] (00m:00s) 3 MB / ?? (2.76 MB/s)\n",
+      "conda-forge/osx-64       [     <=>            ] (00m:00s) 3 MB / ?? (2.72 MB/s)\n",
+      "conda-forge/noarch       [     <=>            ] (00m:00s) 3 MB / ?? (2.74 MB/s)\n",
+      "pkgs/main/osx-64         [      <=>           ] (00m:00s) 3 MB / ?? (2.76 MB/s)\n",
+      "conda-forge/osx-64       [     <=>            ] (00m:00s) 3 MB / ?? (2.72 MB/s)\n",
+      "conda-forge/noarch       [     <=>            ] (00m:00s) 3 MB / ?? (2.74 MB/s)\n",
+      "pkgs/main/osx-64         [      <=>           ] (00m:00s) 4 MB / ?? (2.98 MB/s)\n",
+      "conda-forge/osx-64       [      <=>           ] (00m:00s) 3 MB / ?? (2.72 MB/s)\n",
+      "conda-forge/noarch       [     <=>            ] (00m:00s) 3 MB / ?? (2.74 MB/s)\n",
+      "pkgs/main/osx-64         [      <=>           ] (00m:00s) 4 MB / ?? (2.98 MB/s)\n",
+      "conda-forge/osx-64       [      <=>           ] (00m:00s) 3 MB / ?? (2.81 MB/s)\n",
+      "conda-forge/noarch       [     <=>            ] (00m:00s) 3 MB / ?? (2.74 MB/s)\n",
+      "pkgs/main/osx-64         [      <=>           ] (00m:00s) 4 MB / ?? (2.98 MB/s)\n",
+      "conda-forge/osx-64       [      <=>           ] (00m:00s) 3 MB / ?? (2.81 MB/s)\n",
+      "conda-forge/noarch       [      <=>           ] (00m:00s) 3 MB / ?? (2.74 MB/s)\n",
+      "pkgs/main/osx-64         [      <=>           ] (00m:00s) 4 MB / ?? (2.98 MB/s)\n",
+      "conda-forge/osx-64       [      <=>           ] (00m:00s) 3 MB / ?? (2.81 MB/s)\n",
+      "conda-forge/noarch       [      <=>           ] (00m:00s) 3 MB / ?? (2.87 MB/s)\n",
+      "pkgs/main/osx-64         [      <=>           ] (00m:00s) 4 MB / ?? (2.98 MB/s)\n",
+      "conda-forge/osx-64       [      <=>           ] (00m:01s) 3 MB / ?? (2.81 MB/s)\n",
+      "conda-forge/noarch       [      <=>           ] (00m:01s) 3 MB / ?? (2.87 MB/s)\n",
+      "pkgs/main/osx-64         [      <=>           ] (00m:01s) Finalizing...\n",
+      "conda-forge/osx-64       [      <=>           ] (00m:01s) 3 MB / ?? (2.81 MB/s)\n",
+      "conda-forge/noarch       [      <=>           ] (00m:01s) 3 MB / ?? (2.87 MB/s)\n",
+      "pkgs/main/osx-64         [      <=>           ] (00m:01s) Done\n",
+      "conda-forge/osx-64       [      <=>           ] (00m:01s) 3 MB / ?? (2.81 MB/s)\n",
+      "conda-forge/noarch       [      <=>           ] (00m:01s) 3 MB / ?? (2.87 MB/s)\n",
+      "pkgs/main/osx-64         [====================] (00m:01s) Done\n",
+      "pkgs/main/osx-64         [====================] (00m:01s) Done\n",
+      "conda-forge/osx-64       [      <=>           ] (00m:01s) 3 MB / ?? (2.81 MB/s)\n",
+      "conda-forge/noarch       [      <=>           ] (00m:01s) 3 MB / ?? (2.87 MB/s)\n",
+      "conda-forge/osx-64       [       <=>          ] (00m:01s) 3 MB / ?? (2.81 MB/s)\n",
+      "conda-forge/noarch       [      <=>           ] (00m:01s) 3 MB / ?? (2.87 MB/s)\n",
+      "conda-forge/osx-64       [       <=>          ] (00m:01s) 4 MB / ?? (2.62 MB/s)\n",
+      "conda-forge/noarch       [      <=>           ] (00m:01s) 3 MB / ?? (2.87 MB/s)\n",
+      "conda-forge/osx-64       [       <=>          ] (00m:01s) 4 MB / ?? (2.62 MB/s)\n",
+      "conda-forge/noarch       [       <=>          ] (00m:01s) 3 MB / ?? (2.87 MB/s)\n",
+      "conda-forge/osx-64       [       <=>          ] (00m:01s) 4 MB / ?? (2.62 MB/s)\n",
+      "conda-forge/noarch       [       <=>          ] (00m:01s) 4 MB / ?? (2.72 MB/s)\n",
+      "conda-forge/osx-64       [        <=>         ] (00m:01s) 4 MB / ?? (2.62 MB/s)\n",
+      "conda-forge/noarch       [       <=>          ] (00m:01s) 4 MB / ?? (2.72 MB/s)\n",
+      "conda-forge/osx-64       [        <=>         ] (00m:01s) 5 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/noarch       [       <=>          ] (00m:01s) 4 MB / ?? (2.72 MB/s)\n",
+      "conda-forge/osx-64       [        <=>         ] (00m:01s) 5 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/noarch       [        <=>         ] (00m:01s) 4 MB / ?? (2.72 MB/s)\n",
+      "conda-forge/osx-64       [        <=>         ] (00m:01s) 5 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/noarch       [        <=>         ] (00m:01s) 5 MB / ?? (3.00 MB/s)\n",
+      "conda-forge/osx-64       [         <=>        ] (00m:01s) 5 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/noarch       [        <=>         ] (00m:01s) 5 MB / ?? (3.00 MB/s)\n",
+      "conda-forge/osx-64       [         <=>        ] (00m:01s) 5 MB / ?? (3.10 MB/s)\n",
+      "conda-forge/noarch       [        <=>         ] (00m:01s) 5 MB / ?? (3.00 MB/s)\n",
+      "conda-forge/osx-64       [         <=>        ] (00m:01s) 5 MB / ?? (3.10 MB/s)\n",
+      "conda-forge/noarch       [         <=>        ] (00m:01s) 5 MB / ?? (3.00 MB/s)\n",
+      "conda-forge/osx-64       [         <=>        ] (00m:01s) 5 MB / ?? (3.10 MB/s)\n",
+      "conda-forge/noarch       [         <=>        ] (00m:01s) 5 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/osx-64       [          <=>       ] (00m:01s) 5 MB / ?? (3.10 MB/s)\n",
+      "conda-forge/noarch       [         <=>        ] (00m:01s) 5 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/osx-64       [          <=>       ] (00m:01s) 6 MB / ?? (3.09 MB/s)\n",
+      "conda-forge/noarch       [         <=>        ] (00m:01s) 5 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/osx-64       [          <=>       ] (00m:01s) 6 MB / ?? (3.09 MB/s)\n",
+      "conda-forge/noarch       [          <=>       ] (00m:01s) 5 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/osx-64       [          <=>       ] (00m:01s) 6 MB / ?? (3.09 MB/s)\n",
+      "conda-forge/noarch       [          <=>       ] (00m:01s) 6 MB / ?? (2.99 MB/s)\n",
+      "conda-forge/osx-64       [           <=>      ] (00m:01s) 6 MB / ?? (3.09 MB/s)\n",
+      "conda-forge/noarch       [          <=>       ] (00m:01s) 6 MB / ?? (2.99 MB/s)\n",
+      "conda-forge/osx-64       [           <=>      ] (00m:01s) 6 MB / ?? (3.05 MB/s)\n",
+      "conda-forge/noarch       [          <=>       ] (00m:01s) 6 MB / ?? (2.99 MB/s)\n",
+      "conda-forge/osx-64       [           <=>      ] (00m:01s) 6 MB / ?? (3.05 MB/s)\n",
+      "conda-forge/noarch       [           <=>      ] (00m:01s) 6 MB / ?? (2.99 MB/s)\n",
+      "conda-forge/osx-64       [           <=>      ] (00m:01s) 6 MB / ?? (3.05 MB/s)\n",
+      "conda-forge/noarch       [           <=>      ] (00m:01s) 6 MB / ?? (3.02 MB/s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "conda-forge/osx-64       [            <=>     ] (00m:01s) 6 MB / ?? (3.05 MB/s)\n",
+      "conda-forge/noarch       [           <=>      ] (00m:01s) 6 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/osx-64       [            <=>     ] (00m:01s) 6 MB / ?? (2.94 MB/s)\n",
+      "conda-forge/noarch       [           <=>      ] (00m:01s) 6 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/osx-64       [            <=>     ] (00m:01s) 6 MB / ?? (2.94 MB/s)\n",
+      "conda-forge/noarch       [            <=>     ] (00m:01s) 6 MB / ?? (3.02 MB/s)\n",
+      "conda-forge/osx-64       [            <=>     ] (00m:01s) 6 MB / ?? (2.94 MB/s)\n",
+      "conda-forge/noarch       [            <=>     ] (00m:01s) 7 MB / ?? (3.01 MB/s)\n",
+      "conda-forge/osx-64       [             <=>    ] (00m:02s) 6 MB / ?? (2.94 MB/s)\n",
+      "conda-forge/noarch       [            <=>     ] (00m:02s) 7 MB / ?? (3.01 MB/s)\n",
+      "conda-forge/osx-64       [             <=>    ] (00m:02s) 7 MB / ?? (2.94 MB/s)\n",
+      "conda-forge/noarch       [            <=>     ] (00m:02s) 7 MB / ?? (3.01 MB/s)\n",
+      "conda-forge/osx-64       [             <=>    ] (00m:02s) 7 MB / ?? (2.94 MB/s)\n",
+      "conda-forge/noarch       [             <=>    ] (00m:02s) 7 MB / ?? (3.01 MB/s)\n",
+      "conda-forge/osx-64       [             <=>    ] (00m:02s) 7 MB / ?? (2.94 MB/s)\n",
+      "conda-forge/noarch       [             <=>    ] (00m:02s) 7 MB / ?? (3.01 MB/s)\n",
+      "conda-forge/osx-64       [              <=>   ] (00m:02s) 7 MB / ?? (2.94 MB/s)\n",
+      "conda-forge/noarch       [             <=>    ] (00m:02s) 7 MB / ?? (3.01 MB/s)\n",
+      "conda-forge/osx-64       [              <=>   ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [             <=>    ] (00m:02s) 7 MB / ?? (3.01 MB/s)\n",
+      "conda-forge/osx-64       [              <=>   ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [              <=>   ] (00m:02s) 7 MB / ?? (3.01 MB/s)\n",
+      "conda-forge/osx-64       [              <=>   ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [              <=>   ] (00m:02s) 8 MB / ?? (3.05 MB/s)\n",
+      "conda-forge/osx-64       [               <=>  ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [              <=>   ] (00m:02s) 8 MB / ?? (3.05 MB/s)\n",
+      "conda-forge/osx-64       [               <=>  ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [              <=>   ] (00m:02s) 8 MB / ?? (3.05 MB/s)\n",
+      "conda-forge/osx-64       [               <=>  ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [               <=>  ] (00m:02s) 8 MB / ?? (3.05 MB/s)\n",
+      "conda-forge/osx-64       [               <=>  ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [               <=>  ] (00m:02s) 8 MB / ?? (2.98 MB/s)\n",
+      "conda-forge/osx-64       [                <=> ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [               <=>  ] (00m:02s) 8 MB / ?? (2.98 MB/s)\n",
+      "conda-forge/osx-64       [                <=> ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [               <=>  ] (00m:02s) 8 MB / ?? (2.98 MB/s)\n",
+      "conda-forge/osx-64       [                <=> ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [                <=> ] (00m:02s) 8 MB / ?? (2.98 MB/s)\n",
+      "conda-forge/osx-64       [                <=> ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [                <=> ] (00m:02s) 8 MB / ?? (2.88 MB/s)\n",
+      "conda-forge/osx-64       [                <=> ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [                <=> ] (00m:02s) Finalizing...\n",
+      "conda-forge/osx-64       [                <=> ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [                <=> ] (00m:02s) Done\n",
+      "conda-forge/osx-64       [                <=> ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/noarch       [====================] (00m:02s) Done\n",
+      "conda-forge/noarch       [====================] (00m:02s) Done\n",
+      "conda-forge/osx-64       [                <=> ] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/osx-64       [                 <=>] (00m:02s) 8 MB / ?? (3.06 MB/s)\n",
+      "conda-forge/osx-64       [                 <=>] (00m:02s) 9 MB / ?? (2.86 MB/s)\n",
+      "conda-forge/osx-64       [                  <=] (00m:02s) 9 MB / ?? (2.86 MB/s)\n",
+      "conda-forge/osx-64       [                 <=] (00m:02s) 10 MB / ?? (3.12 MB/s)\n",
+      "conda-forge/osx-64       [                  <] (00m:03s) 10 MB / ?? (3.12 MB/s)\n",
+      "conda-forge/osx-64       [                  <] (00m:03s) 10 MB / ?? (3.13 MB/s)\n",
+      "conda-forge/osx-64       [                  <] (00m:03s) 10 MB / ?? (3.13 MB/s)\n",
+      "conda-forge/osx-64       [                  <] (00m:03s) 11 MB / ?? (3.15 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:03s) 11 MB / ?? (3.15 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:03s) 11 MB / ?? (3.17 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:03s) 11 MB / ?? (3.17 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:03s) 12 MB / ?? (3.20 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:03s) 12 MB / ?? (3.20 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:03s) 13 MB / ?? (3.22 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:03s) 13 MB / ?? (3.22 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:03s) 13 MB / ?? (3.25 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:03s) 13 MB / ?? (3.25 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:03s) 14 MB / ?? (3.28 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 14 MB / ?? (3.28 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 14 MB / ?? (3.29 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 14 MB / ?? (3.29 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 15 MB / ?? (3.30 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 15 MB / ?? (3.30 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 15 MB / ?? (3.31 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 15 MB / ?? (3.31 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 16 MB / ?? (3.30 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 16 MB / ?? (3.30 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 16 MB / ?? (3.27 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 16 MB / ?? (3.27 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 17 MB / ?? (3.26 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 17 MB / ?? (3.26 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:04s) 17 MB / ?? (3.29 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 17 MB / ?? (3.29 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 18 MB / ?? (3.28 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 18 MB / ?? (3.28 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 18 MB / ?? (3.27 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 18 MB / ?? (3.27 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 19 MB / ?? (3.28 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 19 MB / ?? (3.28 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 19 MB / ?? (3.28 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 19 MB / ?? (3.28 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 20 MB / ?? (3.31 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 20 MB / ?? (3.31 MB/s)\n",
+      "conda-forge/osx-64       [                   ] (00m:05s) 21 MB / ?? (3.32 MB/s)\n",
+      "conda-forge/osx-64       [                    ] (00m:05s) Finalizing...\n",
+      "conda-forge/osx-64       [                    ] (00m:06s) Done\n",
+      "conda-forge/osx-64       [====================] (00m:06s) Done\n",
+      "conda-forge/osx-64       [====================] (00m:06s) Done\n",
+      "\n",
+      "Looking for: ['aerobulk-python']\n",
+      "\n",
+      "Transaction\n",
+      "\n",
+      "  Prefix: /Users/paige/opt/anaconda3\n",
+      "\n",
+      "  Updating specs:\n",
+      "\n",
+      "   - aerobulk-python\n",
+      "\n",
+      "\n",
+      "  Package              Version  Build                   Channel                  Size\n",
+      "───────────────────────────────────────────────────────────────────────────────────────\n",
+      "  Install:\n",
+      "───────────────────────────────────────────────────────────────────────────────────────\n",
+      "\n",
+      "\u001b[32m  aerobulk-python\u001b[00m        0.2.4  py38h5abbbee_0          conda-forge/osx-64     348 KB\n",
+      "\u001b[32m  cached-property\u001b[00m        1.5.2  hd8ed1ab_1              conda-forge/noarch\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[32m  cached_property\u001b[00m        1.5.2  pyha770c72_1            conda-forge/noarch\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[32m  libblas        \u001b[00m        3.9.0  9_mkl                   conda-forge/osx-64      12 KB\n",
+      "\u001b[32m  libcblas       \u001b[00m        3.9.0  9_mkl                   conda-forge/osx-64      11 KB\n",
+      "\u001b[32m  libgfortran5   \u001b[00m        9.3.0  h6c81a4c_23             conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[32m  liblapack      \u001b[00m        3.9.0  9_mkl                   conda-forge/osx-64      11 KB\n",
+      "\u001b[32m  libnghttp2     \u001b[00m       1.47.0  h942079c_0              conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[32m  libzip         \u001b[00m        1.8.0  h8b0c345_1              conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[32m  libzlib        \u001b[00m       1.2.12  hfe4f2af_1              conda-forge/osx-64      63 KB\n",
+      "\u001b[32m  xarray         \u001b[00m     2022.3.0  pyhd8ed1ab_0            conda-forge/noarch\u001b[32m     Cached\u001b[00m\n",
+      "\n",
+      "  Upgrade:\n",
+      "───────────────────────────────────────────────────────────────────────────────────────\n",
+      "\n",
+      "\u001b[31m  c-ares         \u001b[00m       1.17.1  h9ed2024_0              installed                    \n",
+      "\u001b[32m  c-ares         \u001b[00m       1.18.1  h0d85af4_0              conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[31m  ca-certificates\u001b[00m  2022.5.18.1  h033912b_0              installed                    \n",
+      "\u001b[32m  ca-certificates\u001b[00m    2022.6.15  h033912b_0              conda-forge/osx-64     149 KB\n",
+      "\u001b[31m  certifi        \u001b[00m  2022.5.18.1  py38h50d1736_0          installed                    \n",
+      "\u001b[32m  certifi        \u001b[00m    2022.6.15  py38h50d1736_0          conda-forge/osx-64     155 KB\n",
+      "\u001b[31m  curl           \u001b[00m       7.71.1  hb0a8c7a_1              installed                    \n",
+      "\u001b[32m  curl           \u001b[00m       7.83.1  h372c54d_0              conda-forge/osx-64     147 KB\n",
+      "\u001b[31m  h5py           \u001b[00m       2.10.0  py38h3134771_0          installed                    \n",
+      "\u001b[32m  h5py           \u001b[00m        3.6.0  nompi_py38h9f21798_100  conda-forge/osx-64       1 MB\n",
+      "\u001b[31m  hdf4           \u001b[00m       4.2.13  0                       installed                    \n",
+      "\u001b[32m  hdf4           \u001b[00m       4.2.15  hefd3b78_3              conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[31m  hdf5           \u001b[00m       1.10.4  hfa1e0ec_0              installed                    \n",
+      "\u001b[32m  hdf5           \u001b[00m       1.12.1  nompi_ha60fbc9_104      conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[31m  jpeg           \u001b[00m           9b  he5867d9_2              installed                    \n",
+      "\u001b[32m  jpeg           \u001b[00m           9e  h5eb16cf_1              conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[31m  krb5           \u001b[00m       1.18.2  h75d18d8_0              installed                    \n",
+      "\u001b[32m  krb5           \u001b[00m       1.19.3  hb49756b_0              conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[31m  libcurl        \u001b[00m       7.71.1  h8a08a2b_1              installed                    \n",
+      "\u001b[32m  libcurl        \u001b[00m       7.83.1  h372c54d_0              conda-forge/osx-64     317 KB\n",
+      "\u001b[31m  libcxx         \u001b[00m       10.0.0  1                       installed                    \n",
+      "\u001b[32m  libcxx         \u001b[00m       14.0.5  hce7ea42_1              conda-forge/osx-64       1 MB\n",
+      "\u001b[31m  libgfortran    \u001b[00m        3.0.1  h93005f0_2              installed                    \n",
+      "\u001b[32m  libgfortran    \u001b[00m        5.0.0  9_3_0_h6c81a4c_23       conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[31m  libnetcdf      \u001b[00m        4.7.3  he3b6227_0              installed                    \n",
+      "\u001b[32m  libnetcdf      \u001b[00m        4.8.1  nompi_h6609ca0_102      conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[31m  libssh2        \u001b[00m        1.9.0  ha12b0ac_1              installed                    \n",
+      "\u001b[32m  libssh2        \u001b[00m       1.10.0  h52ee1ee_2              conda-forge/osx-64\u001b[32m     Cached\u001b[00m\n",
+      "\u001b[31m  netcdf4        \u001b[00m        1.5.3  py38h28545a2_0          installed                    \n",
+      "\u001b[32m  netcdf4        \u001b[00m        1.5.8  nompi_py38h465ef27_101  conda-forge/osx-64     430 KB\n",
+      "\u001b[31m  pytables       \u001b[00m        3.6.1  py38h4727e94_0          installed                    \n",
+      "\u001b[32m  pytables       \u001b[00m        3.7.0  py38h5215406_0          conda-forge/osx-64       2 MB\n",
+      "\u001b[31m  scipy          \u001b[00m        1.6.2  py38hd5f7400_1          installed                    \n",
+      "\u001b[32m  scipy          \u001b[00m        1.8.1  py38h2c99f22_0          conda-forge/osx-64      22 MB\n",
+      "\u001b[31m  zlib           \u001b[00m       1.2.11  h1de35cc_3              installed                    \n",
+      "\u001b[32m  zlib           \u001b[00m       1.2.12  hfe4f2af_1              conda-forge/osx-64      93 KB\n",
+      "\n",
+      "  Summary:\n",
+      "\n",
+      "  Install: 11 packages\n",
+      "  Upgrade: 18 packages\n",
+      "\n",
+      "  Total download: 28 MB\n",
+      "\n",
+      "───────────────────────────────────────────────────────────────────────────────────────\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "certifi                  [====================] (00m:00s) \n",
+      "certifi                  [====================] (00m:00s) Validating...\n",
+      "certifi                  [====================] (00m:00s) Waiting...\n",
+      "certifi                  [====================] (00m:00s) Decompressing...\n",
+      "\u001b[1A\u001b[0KFinished certifi                              (00m:00s)             155 KB    652 KB/s\n",
+      "ca-certificates          [====================] (00m:00s) \n",
+      "ca-certificates          [====================] (00m:00s) Validating...\n",
+      "ca-certificates          [====================] (00m:00s) Waiting...\n",
+      "ca-certificates          [====================] (00m:00s) Decompressing...\n",
+      "\u001b[1A\u001b[0KFinished ca-certificates                      (00m:00s)             149 KB    566 KB/s\n",
+      "libcurl                  [====================] (00m:00s) \n",
+      "libcurl                  [====================] (00m:00s) Validating...\n",
+      "libcurl                  [====================] (00m:00s) Waiting...\n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "curl                     [===>                ] (00m:00s) \n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "curl                     [=>    ] (00m:00s)     28 KB /    147 KB ( 94.94 KB/s)\n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "curl                     [=>    ] (00m:00s)     28 KB /    147 KB ( 94.94 KB/s)\n",
+      "h5py                     [====>               ] (00m:00s) \n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "curl                     [=>    ] (00m:00s)     28 KB /    147 KB ( 94.94 KB/s)\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "curl                     [======] (00m:00s)     28 KB /    147 KB ( 94.94 KB/s)\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "curl                     [====================] (00m:00s) Validating...\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "curl                     [====================] (00m:00s) Waiting...\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "curl                     [====================] (00m:00s) Waiting...\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcblas                 [====================] (00m:00s) \n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "curl                     [====================] (00m:00s) Waiting...\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcblas                 [====================] (00m:00s) Validating...\n",
+      "libcurl                  [====================] (00m:00s) Decompressing...\n",
+      "curl                     [====================] (00m:00s) Waiting...\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcblas                 [====================] (00m:00s) Waiting...\n",
+      "\u001b[4A\u001b[0KFinished libcurl                              (00m:00s)             317 KB      1 MB/s\n",
+      "curl                     [====================] (00m:00s) Waiting...\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcblas                 [====================] (00m:00s) Waiting...\n",
+      "curl                     [====================] (00m:00s) Decompressing...\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcblas                 [====================] (00m:00s) Waiting...\n",
+      "curl                     [====================] (00m:00s) Decompressing...\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcblas                 [====================] (00m:00s) Decompressing...\n",
+      "\u001b[3A\u001b[0KFinished curl                                 (00m:00s)             147 KB    467 KB/s\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libcblas                 [====================] (00m:00s) Decompressing...\n",
+      "\u001b[2A\u001b[0KFinished libcblas                             (00m:00s)              11 KB     35 KB/s\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libzlib                  [====================] (00m:00s) \n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libzlib                  [====================] (00m:00s) Validating...\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libzlib                  [====================] (00m:00s) Waiting...\n",
+      "h5py                     [=>    ] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libzlib                  [====================] (00m:00s) Decompressing...\n",
+      "h5py                     [======] (00m:00s)    275 KB /      1 MB (917.60 KB/s)\n",
+      "libzlib                  [====================] (00m:00s) Decompressing...\n",
+      "h5py                     [====================] (00m:00s) Validating...\n",
+      "libzlib                  [====================] (00m:00s) Decompressing...\n",
+      "h5py                     [====================] (00m:00s) Waiting...\n",
+      "libzlib                  [====================] (00m:00s) Decompressing...\n",
+      "\u001b[2A\u001b[0KFinished libzlib                              (00m:00s)              63 KB    149 KB/s\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) \n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Validating...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>                   ] (00m:00s) \n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) \n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Validating...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) \n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Validating...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) \n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Validating...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) \n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Validating...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)    591 KB /     22 MB (  1.22 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)      2 MB /     22 MB (  2.88 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)      2 MB /     22 MB (  2.88 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [======>             ] (00m:00s) \n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)      2 MB /     22 MB (  2.88 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [=>    ] (00m:00s)    623 KB /      2 MB (973.88 KB/s)\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)      2 MB /     22 MB (  2.88 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [=>    ] (00m:00s)    623 KB /      2 MB (973.88 KB/s)\n",
+      "libcxx                   [====>               ] (00m:00s) \n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)      2 MB /     22 MB (  2.88 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [=>    ] (00m:00s)    623 KB /      2 MB (973.88 KB/s)\n",
+      "libcxx                   [=>    ] (00m:00s)    319 KB /      1 MB (495.01 KB/s)\n",
+      "h5py                     [====================] (00m:00s) Decompressing...\n",
+      "netcdf4                  [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [>     ] (00m:00s)      2 MB /     22 MB (  2.88 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [=>    ] (00m:00s)    623 KB /      2 MB (973.88 KB/s)\n",
+      "libcxx                   [=>    ] (00m:00s)    319 KB /      1 MB (495.01 KB/s)\n",
+      "\u001b[9A\u001b[0KFinished h5py                                 (00m:00s)               1 MB      3 MB/s\n",
+      "netcdf4                  [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [>     ] (00m:00s)      2 MB /     22 MB (  2.88 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Waiting...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [=>    ] (00m:00s)    623 KB /      2 MB (973.88 KB/s)\n",
+      "libcxx                   [=>    ] (00m:00s)    319 KB /      1 MB (495.01 KB/s)\n",
+      "netcdf4                  [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [>     ] (00m:00s)      2 MB /     22 MB (  2.88 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Decompressing...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [=>    ] (00m:00s)    623 KB /      2 MB (973.88 KB/s)\n",
+      "libcxx                   [=>    ] (00m:00s)    319 KB /      1 MB (495.01 KB/s)\n",
+      "\u001b[8A\u001b[0KFinished netcdf4                              (00m:00s)             430 KB    962 KB/s\n",
+      "scipy                    [>     ] (00m:00s)      2 MB /     22 MB (  2.88 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Decompressing...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [=>    ] (00m:00s)    623 KB /      2 MB (973.88 KB/s)\n",
+      "libcxx                   [=>    ] (00m:00s)    319 KB /      1 MB (495.01 KB/s)\n",
+      "scipy                    [>     ] (00m:00s)      2 MB /     22 MB (  2.88 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Decompressing...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [=>    ] (00m:00s)    623 KB /      2 MB (973.88 KB/s)\n",
+      "libcxx                   [=>    ] (00m:00s)    319 KB /      1 MB (495.01 KB/s)\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Decompressing...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [=>    ] (00m:00s)    623 KB /      2 MB (973.88 KB/s)\n",
+      "libcxx                   [=>    ] (00m:00s)    319 KB /      1 MB (495.01 KB/s)\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Decompressing...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [====> ] (00m:00s)    623 KB /      2 MB (973.88 KB/s)\n",
+      "libcxx                   [=>    ] (00m:00s)    319 KB /      1 MB (495.01 KB/s)\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Decompressing...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [=>    ] (00m:00s)    319 KB /      1 MB (495.01 KB/s)\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Decompressing...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====> ] (00m:00s)    319 KB /      1 MB (495.01 KB/s)\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "aerobulk-python          [====================] (00m:00s) Decompressing...\n",
+      "libblas                  [====================] (00m:00s) Waiting...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====> ] (00m:00s)   1006 KB /      1 MB (  1.24 MB/s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\u001b[7A\u001b[0KFinished aerobulk-python                      (00m:00s)             348 KB    715 KB/s\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "libblas                  [====================] (00m:00s) Decompressing...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====> ] (00m:00s)   1006 KB /      1 MB (  1.24 MB/s)\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "libblas                  [====================] (00m:00s) Decompressing...\n",
+      "liblapack                [====================] (00m:00s) Waiting...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====> ] (00m:00s)   1006 KB /      1 MB (  1.24 MB/s)\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "libblas                  [====================] (00m:00s) Decompressing...\n",
+      "liblapack                [====================] (00m:00s) Decompressing...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====> ] (00m:00s)   1006 KB /      1 MB (  1.24 MB/s)\n",
+      "\u001b[6A\u001b[0KFinished libblas                              (00m:00s)              12 KB     24 KB/s\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "liblapack                [====================] (00m:00s) Decompressing...\n",
+      "zlib                     [====================] (00m:00s) Waiting...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====> ] (00m:00s)   1006 KB /      1 MB (  1.24 MB/s)\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "liblapack                [====================] (00m:00s) Decompressing...\n",
+      "zlib                     [====================] (00m:00s) Decompressing...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====> ] (00m:00s)   1006 KB /      1 MB (  1.24 MB/s)\n",
+      "\u001b[5A\u001b[0KFinished liblapack                            (00m:00s)              11 KB     23 KB/s\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "zlib                     [====================] (00m:00s) Decompressing...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====> ] (00m:00s)   1006 KB /      1 MB (  1.24 MB/s)\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "zlib                     [====================] (00m:00s) Decompressing...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [======] (00m:00s)   1006 KB /      1 MB (  1.24 MB/s)\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "zlib                     [====================] (00m:00s) Decompressing...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====================] (00m:00s) Validating...\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "zlib                     [====================] (00m:00s) Decompressing...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====================] (00m:00s) Waiting...\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "zlib                     [====================] (00m:00s) Decompressing...\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "\u001b[4A\u001b[0KFinished zlib                                 (00m:00s)              93 KB    178 KB/s\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "pytables                 [====> ] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "pytables                 [======] (00m:00s)      1 MB /      2 MB (  1.77 MB/s)\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Validating...\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [>     ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Waiting...\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [=>    ] (00m:00s)      3 MB /     22 MB (  3.33 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Waiting...\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [=>    ] (00m:00s)      4 MB /     22 MB (  4.17 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Waiting...\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [=>    ] (00m:00s)      4 MB /     22 MB (  4.17 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Waiting...\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [=>    ] (00m:00s)      6 MB /     22 MB (  5.12 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Waiting...\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [=>    ] (00m:00s)      6 MB /     22 MB (  5.12 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Waiting...\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [=>    ] (00m:00s)      7 MB /     22 MB (  6.02 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Waiting...\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [=>    ] (00m:00s)      7 MB /     22 MB (  6.02 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Decompressing...\n",
+      "libcxx                   [====================] (00m:00s) Decompressing...\n",
+      "\u001b[3A\u001b[0KFinished libcxx                               (00m:00s)               1 MB      2 MB/s\n",
+      "scipy                    [=>    ] (00m:00s)      7 MB /     22 MB (  6.02 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [==>   ] (00m:00s)      7 MB /     22 MB (  6.02 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [==>   ] (00m:00s)      9 MB /     22 MB (  6.63 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [===>  ] (00m:01s)      9 MB /     22 MB (  6.63 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [===>  ] (00m:01s)     11 MB /     22 MB (  7.49 MB/s)\n",
+      "pytables                 [====================] (00m:00s) Decompressing...\n",
+      "scipy                    [===>  ] (00m:01s)     11 MB /     22 MB (  7.49 MB/s)\n",
+      "pytables                 [====================] (00m:01s) Decompressing...\n",
+      "scipy                    [===>  ] (00m:01s)     13 MB /     22 MB (  7.80 MB/s)\n",
+      "pytables                 [====================] (00m:01s) Decompressing...\n",
+      "scipy                    [===>  ] (00m:01s)     13 MB /     22 MB (  7.80 MB/s)\n",
+      "pytables                 [====================] (00m:01s) Decompressing...\n",
+      "scipy                    [===>  ] (00m:01s)     14 MB /     22 MB (  7.81 MB/s)\n",
+      "pytables                 [====================] (00m:01s) Decompressing...\n",
+      "\u001b[2A\u001b[0KFinished pytables                             (00m:01s)               2 MB      2 MB/s\n",
+      "scipy                    [===>  ] (00m:01s)     14 MB /     22 MB (  7.81 MB/s)\n",
+      "scipy                    [====> ] (00m:01s)     14 MB /     22 MB (  7.81 MB/s)\n",
+      "scipy                    [====> ] (00m:01s)     17 MB /     22 MB (  8.32 MB/s)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "scipy                    [=====>] (00m:01s)     17 MB /     22 MB (  8.32 MB/s)\n",
+      "scipy                    [=====>] (00m:01s)     19 MB /     22 MB (  8.87 MB/s)\n",
+      "scipy                    [=====>] (00m:01s)     19 MB /     22 MB (  8.87 MB/s)\n",
+      "scipy                    [=====>] (00m:01s)     21 MB /     22 MB (  9.38 MB/s)\n",
+      "scipy                    [======] (00m:01s)     21 MB /     22 MB (  9.38 MB/s)\n",
+      "scipy                    [====================] (00m:01s) Validating...\n",
+      "scipy                    [====================] (00m:01s) Waiting...\n",
+      "scipy                    [====================] (00m:01s) Decompressing...\n",
+      "\u001b[1A\u001b[0KFinished scipy                                (00m:05s)              22 MB      9 MB/s\n",
+      "Preparing transaction: done\n",
+      "Verifying transaction: done\n",
+      "Executing transaction: done\n"
+     ]
+    }
+   ],
+   "source": [
+    "# You need to run this each time when your notebook server was closed (e.g. when you logged out)\n",
+    "!mamba install aerobulk-python -y"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ed48ccd3",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "0.2.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check version\n",
+    "import aerobulk\n",
+    "print(aerobulk.__version__)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "70b6db78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "import xarray as xr\n",
+    "import numpy as np\n",
+    "from aerobulk import noskin, skin\n",
+    "import itertools\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "0f93cd43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Dict, Tuple\n",
+    "import time\n",
+    "import numpy as np\n",
+    "import pytest\n",
+    "import xarray as xr\n",
+    "from aerobulk import noskin\n",
+    "\n",
+    "\"\"\"Tests for the xarray wrapper\"\"\"\n",
+    "\n",
+    "\n",
+    "def create_data(\n",
+    "    shape: Tuple[int, ...],\n",
+    "    chunks: Dict[str, int] = {},\n",
+    "    skin_correction: bool = False,\n",
+    "    order: str = \"F\",\n",
+    "):\n",
+    "    def _arr(value, chunks, order):\n",
+    "        arr = xr.DataArray(np.full(shape, value, order=order))\n",
+    "\n",
+    "        # adds random noise scaled by a percentage of the value\n",
+    "        randomize_factor = 0.001\n",
+    "        randomize_range = value * randomize_factor\n",
+    "        arr = arr + np.random.rand(*shape) + randomize_range\n",
+    "        if chunks:\n",
+    "            arr = arr.chunk(chunks)\n",
+    "        return arr\n",
+    "\n",
+    "    sst = _arr(290.0, chunks, order)\n",
+    "    t_zt = _arr(280.0, chunks, order)\n",
+    "    hum_zt = _arr(0.001, chunks, order)\n",
+    "    u_zu = _arr(1.0, chunks, order)\n",
+    "    v_zu = _arr(-1.0, chunks, order)\n",
+    "    slp = _arr(101000.0, chunks, order)\n",
+    "    rad_sw = _arr(0.000001, chunks, order)\n",
+    "    rad_lw = _arr(350, chunks, order)\n",
+    "    if skin_correction:\n",
+    "        return sst, t_zt, hum_zt, u_zu, v_zu, rad_sw, rad_lw, slp\n",
+    "    else:\n",
+    "        return sst, t_zt, hum_zt, u_zu, v_zu, slp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fc219f8",
+   "metadata": {},
+   "source": [
+    "### Add snakeviz as a \"magic\" extension"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7e25cdb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext snakeviz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8b412f3d",
+   "metadata": {},
+   "source": [
+    "### Run `prun` to profile the functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "id": "2a66ca9f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " "
+     ]
+    }
+   ],
+   "source": [
+    "%prun noskin(*args)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "626376da",
+   "metadata": {},
+   "source": [
+    "Note that the above line of code pulls up a separate window with the results of the call."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8d283fbb",
+   "metadata": {},
+   "source": [
+    "# Use synthetic data the size of CM2.6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "b6b0c66b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 2.78 s, sys: 1.32 s, total: 4.1 s\n",
+      "Wall time: 4.53 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "data = create_data((3600, 2700, 2), chunks=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "17c8bb94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Julius's time check (in s)\n",
+    "tic = time.time()\n",
+    "out_data = noskin(*data)\n",
+    "toc = time.time() - tic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "e8131733",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "68.03498601913452"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "toc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "9f1c7c0b",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " \n",
+      "*** Profile stats marshalled to file '/var/folders/kp/4b8drk090qn632t3j69yth0r0000gn/T/tmpm5kv3c7e'. \n",
+      "Embedding SnakeViz in this document...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<iframe id='snakeviz-00e7c5f6-ee6f-11ec-83bf-acde48001122' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
+       "<script>document.getElementById(\"snakeviz-00e7c5f6-ee6f-11ec-83bf-acde48001122\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Fvar%2Ffolders%2Fkp%2F4b8drk090qn632t3j69yth0r0000gn%2FT%2Ftmpm5kv3c7e\")</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%snakeviz out_data = noskin(*data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 59,
+   "id": "3dddde13",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5.48"
+      ]
+     },
+     "execution_count": 59,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Total time (in s) of other functions besides `noflux_np()`\n",
+    ".08*68.5"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6a05adb",
+   "metadata": {},
+   "source": [
+    "# Use synthetic data of slightly smaller size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "id": "a45d8c33",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 245 ms, sys: 66.3 ms, total: 312 ms\n",
+      "Wall time: 311 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "data = create_data((1000, 1000, 2), chunks=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "id": "56dc3ff4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tic = time.time()\n",
+    "out_data = noskin(*data)\n",
+    "toc = time.time() - tic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "id": "b9aa47b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6.943201065063477"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "toc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "a13c0d8e",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " \n",
+      "*** Profile stats marshalled to file '/var/folders/kp/4b8drk090qn632t3j69yth0r0000gn/T/tmp_nixcnw4'. \n",
+      "Embedding SnakeViz in this document...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<iframe id='snakeviz-692e1b3a-ee7c-11ec-83bf-acde48001122' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
+       "<script>document.getElementById(\"snakeviz-692e1b3a-ee7c-11ec-83bf-acde48001122\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Fvar%2Ffolders%2Fkp%2F4b8drk090qn632t3j69yth0r0000gn%2FT%2Ftmp_nixcnw4\")</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%snakeviz out_data = noskin(*data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "id": "4eb89f0e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1.316"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Total time (in s) of other functions besides `noflux_np()`\n",
+    ".2*6.58"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5750c242",
+   "metadata": {},
+   "source": [
+    "# Use synthetic data of much smaller size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "id": "afe8172f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 4.59 ms, sys: 2.87 ms, total: 7.46 ms\n",
+      "Wall time: 5.9 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "data = create_data((100, 100, 2), chunks=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 47,
+   "id": "9239708f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tic = time.time()\n",
+    "out_data = noskin(*data)\n",
+    "toc = time.time() - tic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 48,
+   "id": "52f1fa9d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.08172988891601562"
+      ]
+     },
+     "execution_count": 48,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "toc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 50,
+   "id": "ef04a359",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " \n",
+      "*** Profile stats marshalled to file '/var/folders/kp/4b8drk090qn632t3j69yth0r0000gn/T/tmpqmdv0zd0'. \n",
+      "Embedding SnakeViz in this document...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<iframe id='snakeviz-9fc788d0-ee7b-11ec-83bf-acde48001122' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
+       "<script>document.getElementById(\"snakeviz-9fc788d0-ee7b-11ec-83bf-acde48001122\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Fvar%2Ffolders%2Fkp%2F4b8drk090qn632t3j69yth0r0000gn%2FT%2Ftmpqmdv0zd0\")</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%snakeviz out_data = noskin(*data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 63,
+   "id": "1112a6ad",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.667184"
+      ]
+     },
+     "execution_count": 63,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Total time (in s) of other functions besides `noflux_np()`\n",
+    "7.84*.0851"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b90a8d8",
+   "metadata": {},
+   "source": [
+    "# Use synthetic data of even smaller size"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 51,
+   "id": "f843b2a8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 1.49 ms, sys: 594 µs, total: 2.08 ms\n",
+      "Wall time: 2.02 ms\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "data = create_data((10, 10, 2), chunks=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "id": "a16cfa53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tic = time.time()\n",
+    "out_data = noskin(*data)\n",
+    "toc = time.time() - tic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "991215b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.004825115203857422"
+      ]
+     },
+     "execution_count": 53,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "toc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "id": "5c66c7d2",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " \n",
+      "*** Profile stats marshalled to file '/var/folders/kp/4b8drk090qn632t3j69yth0r0000gn/T/tmp1pn9t3ad'. \n",
+      "Embedding SnakeViz in this document...\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "\n",
+       "<iframe id='snakeviz-ae178e58-ee7b-11ec-83bf-acde48001122' frameborder=0 seamless width='100%' height='1000'></iframe>\n",
+       "<script>document.getElementById(\"snakeviz-ae178e58-ee7b-11ec-83bf-acde48001122\").setAttribute(\"src\", \"http://\" + document.location.hostname + \":8080/snakeviz/%2Fvar%2Ffolders%2Fkp%2F4b8drk090qn632t3j69yth0r0000gn%2FT%2Ftmp1pn9t3ad\")</script>\n"
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%snakeviz out_data = noskin(*data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 62,
+   "id": "9ecd9324",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0.6753264"
+      ]
+     },
+     "execution_count": 62,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Total time (in s) of other functions besides `noflux_np()`\n",
+    "84.84*.00796"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "885dbf41",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.8"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": false,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Adding a notebook with some `aerobulk-python` profiling in a first attempt to understand why it is so slow to run. I used `snakeviz` to do the profiling and only used sample data. See issue #28 